### PR TITLE
Increasing timeout to 60 seconds (instead of 6)

### DIFF
--- a/server.properties
+++ b/server.properties
@@ -17,7 +17,7 @@
 ############################# Server Basics #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.
-broker.id=-1
+broker.id                         =-1
 
 ############################# Socket Server Settings #############################
 
@@ -35,34 +35,34 @@ broker.id=-1
 #advertised.listeners=PLAINTEXT://your.host.name:9092
 
 # The number of threads handling network requests
-num.network.threads=3
+num.network.threads               =3
 
 # The number of threads doing disk I/O
-num.io.threads=8
+num.io.threads                    =8
 
 # The send buffer (SO_SNDBUF) used by the socket server
-socket.send.buffer.bytes=102400
+socket.send.buffer.bytes          =102400
 
 # The receive buffer (SO_RCVBUF) used by the socket server
-socket.receive.buffer.bytes=102400
+socket.receive.buffer.bytes       =102400
 
 # The maximum size of a request that the socket server will accept (protection against OOM)
-socket.request.max.bytes=104857600
+socket.request.max.bytes          =104857600
 
 
 ############################# Log Basics #############################
 
 # A comma seperated list of directories under which to store log files
-log.dirs=/tmp/kafka-logs
+log.dirs                          =/tmp/kafka-logs
 
 # The default number of log partitions per topic. More partitions allow greater
 # parallelism for consumption, but this will also result in more files across
 # the brokers.
-num.partitions=1
+num.partitions                    =1
 
 # The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
 # This value is recommended to be increased for installations with data dirs located in RAID array.
-num.recovery.threads.per.data.dir=1
+num.recovery.threads.per.data.dir =1
 
 ############################# Log Flush Policy #############################
 
@@ -89,18 +89,18 @@ num.recovery.threads.per.data.dir=1
 # from the end of the log.
 
 # The minimum age of a log file to be eligible for deletion
-log.retention.hours=168
+log.retention.hours               =168
 
 # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
 # segments don't drop below log.retention.bytes.
 #log.retention.bytes=1073741824
 
 # The maximum size of a log segment file. When this size is reached a new log segment will be created.
-log.segment.bytes=1073741824
+log.segment.bytes                 =1073741824
 
 # The interval at which log segments are checked to see if they can be deleted according
 # to the retention policies
-log.retention.check.interval.ms=300000
+log.retention.check.interval.ms   =300000
 
 ############################# Zookeeper #############################
 
@@ -109,10 +109,10 @@ log.retention.check.interval.ms=300000
 # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 # You can also append an optional chroot string to the urls to specify the
 # root directory for all kafka znodes.
-zookeeper.connect=zookeeper:2181
+zookeeper.connect                 =zookeeper:2181
 
 # Timeout in ms for connecting to zookeeper
-zookeeper.connection.timeout.ms=6000
+zookeeper.connection.timeout.ms   = 60000
 
 ########################## Topics #####################################
 auto.create.topics.enable         = false


### PR DESCRIPTION
appcelerator/amp-project#298

Fixes a timeout issue preventing kafka from connecting to zookeeper
Tested locally before commit
